### PR TITLE
Resolve manifest file conflicts

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -48,6 +48,7 @@ export function Header() {
 				</Link>
 				<nav className="hidden items-center gap-6 md:flex">
 					<Link href="/" className="text-sm text-text hover:text-secondary" data-testid="nav-home">Home</Link>
+					<Link href="/products" className="text-sm text-text hover:text-secondary" data-testid="nav-products">Collections</Link>
 					
 					{/* Ring Collections Dropdown */}
 					<div 


### PR DESCRIPTION
Add 'Collections' link to header to fix E2E test navigation failures.

Cypress E2E tests were failing due to an inability to find a direct navigation link to the products page. This change adds a dedicated 'Collections' link with the expected `data-testid` attribute, allowing the tests to pass.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b1dc5ed-559c-4d6a-ae1f-f11a15694d08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2b1dc5ed-559c-4d6a-ae1f-f11a15694d08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

