### PR TITLE
Scan for risky dynamic imports

### DIFF
--- a/Jewelry.Website/scripts/check-dynamic-imports.mjs
+++ b/Jewelry.Website/scripts/check-dynamic-imports.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Minimal, dependency-free checks for common pitfalls
+
+import fs from 'fs';
+import path from 'path';
+
+const files = process.argv.slice(2);
+let hadError = false;
+
+const problems = [];
+
+const add = (file, line, rule, snippet) => {
+  hadError = true;
+  problems.push({ file, line, rule, snippet });
+};
+
+// Helpers
+const eachLine = (text, cb) => {
+  text.split(/\r?\n/).forEach((line, idx) => cb(line, idx + 1));
+};
+
+for (const file of files) {
+  let text = '';
+  try {
+    text = fs.readFileSync(file, 'utf8');
+  } catch {
+    continue;
+  }
+
+  eachLine(text, (line, ln) => {
+    // 1) Computed dynamic import: import(`...${...}`) or import(someVar)
+    if (/\b(dynamic|lazy)\s*\(/.test(line) || /React\.lazy\s*\(/.test(line)) {
+      // Any import(  that is not followed by a simple quoted string
+      const m = line.match(/import\s*\(([^)]+)\)/);
+      if (m) {
+        const arg = m[1].trim();
+        const isQuoted = /^['"][^'"]+['"]$/.test(arg);
+        const isTemplate = /^`/.test(arg) || /\$\{/.test(arg);
+        const isVariable = !isQuoted && !isTemplate;
+
+        if (isTemplate) {
+          add(file, ln, 'Computed dynamic import (template literal)', line.trim());
+        } else if (isVariable) {
+          add(file, ln, 'Computed dynamic import (variable path)', line.trim());
+        } else {
+          // 2) Barrel/index imports (path ends with /index or /index.ext)
+          const p = arg.slice(1, -1); // strip quotes
+          if (/\/index(\.[a-zA-Z]+)?$/.test(p)) {
+            add(file, ln, 'Dynamic import targets a barrel (/index.*). Use the concrete file.', line.trim());
+          }
+          // 3) Directory-only target (ends with /)
+          if (/\/$/.test(p)) {
+            add(file, ln, 'Dynamic import ends with "/". Use the concrete file, not a folder.', line.trim());
+          }
+        }
+      }
+    }
+
+    // 4) next/dynamic without literal path via thenable (named export mapping allowed)
+    // We only flag obvious misuse: dynamic(() => import(foo))
+    if (/dynamic\s*\(\s*\(\s*=>\s*import\s*\(\s*[a-zA-Z_$]/.test(line)) {
+      add(file, ln, 'dynamic() import uses a variable. Use a literal string path.', line.trim());
+    }
+  });
+}
+
+// Report
+if (hadError) {
+  console.error('\n❌ Blocked commit due to risky lazy/dynamic imports:\n');
+  for (const p of problems) {
+    console.error(`- ${p.file}:${p.line} — ${p.rule}\n  ${p.snippet}`);
+  }
+  console.error(`
+Guidelines:
+  • Use literal file paths: dynamic(() => import('path/to/Component'))
+  • Don't use template strings or variables in import().
+  • Don't target barrels (/index) or folders.
+  • If importing a named export, map it:
+      dynamic(() => import('./Widget').then(m => ({ default: m.Widget })))
+`);
+  process.exit(1);
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary

This PR implements a pre-commit hook to prevent risky lazy/dynamic imports in JavaScript/TypeScript files.

**Key changes:**
- Adds `.git/hooks/pre-commit` to automatically scan staged JS/TS files.
- Introduces `scripts/check-dynamic-imports.mjs` to enforce import guidelines.

**Why this is important:**
- Blocks common pitfalls like computed import paths (template literals, variables), barrel file imports (`/index`), and directory imports (`/`).
- Helps prevent bundle analysis issues, runtime errors, and performance degradation.
- Ensures consistent and predictable module splitting.

- [ ] Health endpoints tested (/api/healthz, /api/readyz)
- [ ] Metrics endpoint verified (/api/metrics)
- [ ] Image audit passed (no RED rows)
- [ ] Security audit reviewed (npm audit)
- [ ] Smoke tests passed

## Screenshots/Logs

Output from the pre-commit hook is displayed directly in the terminal during `git commit` if risky imports are detected. No specific screenshots are attached as the output is console-based.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b6fb21b-53da-4556-9b9d-a20f2e07fd51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b6fb21b-53da-4556-9b9d-a20f2e07fd51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

